### PR TITLE
BUG: Py2/Py3 token decoding

### DIFF
--- a/dtool_lookup_server/cli.py
+++ b/dtool_lookup_server/cli.py
@@ -175,7 +175,7 @@ def generate_token(username, last_forever):
         token = create_access_token(identity=username, expires_delta=False)
     else:
         token = create_access_token(identity=username)
-    click.secho(token.decode("utf-8"))
+    click.secho(token)
 
 
 @base_uri_cli.command(name="index")


### PR DESCRIPTION
As discussed, this requires some Python 2 / Python 3 compatibility workaround:

In the setup

```console
$ python -V
Python 3.7.6

$ pip list
Package                Version
---------------------- -------------------
alembic                1.4.2
asn1crypto             1.3.0
boto3                  1.14.56
botocore               1.17.56
certifi                2019.11.28
cffi                   1.14.0
chardet                3.0.4
click                  7.1.2
click-plugins          1.1.1
conda                  4.8.2
conda-package-handling 1.6.0
cryptography           2.8
docutils               0.15.2
dtool-cli              0.7.0
dtool-ecs              0.4.0
dtool-irods            0.10.0
dtool-lookup-server    0.14.1
dtool-s3               0.10.0
dtool-smb              0.1.0
dtoolcore              3.17.0
Flask                  1.1.2
Flask-Cors             3.0.9
Flask-JWT-Extended     3.24.1
Flask-Migrate          2.5.3
Flask-PyMongo          2.3.0
Flask-SQLAlchemy       2.4.4
gunicorn               20.0.4
idna                   2.8
itsdangerous           1.1.0
Jinja2                 2.11.2
jmespath               0.10.0
Mako                   1.1.3
MarkupSafe             1.1.1
pip                    20.0.2
psycopg2               2.8.5
pyasn1                 0.4.8
pycosat                0.6.3
pycparser              2.19
PyJWT                  1.7.1
pymongo                3.11.0
pyOpenSSL              19.1.0
pysmb                  1.2.2
PySocks                1.7.1
python-dateutil        2.8.1
python-editor          1.0.4
PyYAML                 5.3.1
requests               2.22.0
ruamel-yaml            0.15.87
s3transfer             0.3.3
setuptools             45.2.0.post20200210
six                    1.14.0
SQLAlchemy             1.3.19
tqdm                   4.42.1
urllib3                1.25.8
Werkzeug               1.0.1
wheel                  0.34.2
```

token already is str and thus server throws

```
flask user token jh1130
Traceback (most recent call last):
  File "/opt/conda/bin/flask", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.7/site-packages/flask/cli.py", line 967, in main
    cli.main(args=sys.argv[1:], prog_name="python -m flask" if as_module else None)
  File "/opt/conda/lib/python3.7/site-packages/flask/cli.py", line 586, in main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/flask/cli.py", line 426, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/dtool_lookup_server/cli.py", line 178, in generate_token
    click.secho(token.decode("utf-8"))
AttributeError: 'str' object has no attribute 'decode'
```

when requesting user token with `flask user token ...`