### PR TITLE
config routes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -607,3 +607,12 @@ Response content::
       "users_with_search_permissions": []
     }
 
+Querying server configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The request
+
+    $ curl -H "$HEADER" http://localhost:5000/admin/config/info
+
+will return the current server configuration with all keys in lowercase.
+See ``dtool_lookup_server.config.Config`` for more information.

--- a/README.rst
+++ b/README.rst
@@ -612,38 +612,17 @@ Querying server configuration
 
 The request
 
-    $ curl -H "$HEADER" http://localhost:5000/admin/config/info
+    $ curl -H "$HEADER" http://localhost:5000/config/info
 
-will return the current server configuration with all keys in lowercase::
+will return the current server configuration with all keys in lowercase, i.e.::
 
     {
-      "allow_direct_aggregation": false,
-      "dependency_keys": [
-        "readme.derived_from.uuid",
-        "annotations.source_dataset_uuid"
-      ],
-      "enable_dependency_view": true,
-      "force_rebuild_dependency_view": false,
       "jsonify_prettyprint_regular": true,
       "jwt_algorithm": "RS256",
       "jwt_header_name": "Authorization",
       "jwt_header_type": "Bearer",
       "jwt_public_key": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n",
       "jwt_token_location": "headers",
-      "mongo_collection": "datasets",
-      "mongo_dependency_view": "dependencies",
-      "query_dict_list_keys": [
-        "creator_usernames",
-        "base_uris",
-        "tags"
-      ],
-      "query_dict_valid_keys": [
-        "free_text",
-        "creator_usernames",
-        "base_uris",
-        "tags",
-        "query"
-      ],
       "sqlalchemy_track_modifications": false,
       "version": "0.14.1"
     }

--- a/README.rst
+++ b/README.rst
@@ -614,5 +614,38 @@ The request
 
     $ curl -H "$HEADER" http://localhost:5000/admin/config/info
 
-will return the current server configuration with all keys in lowercase.
+will return the current server configuration with all keys in lowercase::
+
+    {
+      "allow_direct_aggregation": false,
+      "dependency_keys": [
+        "readme.derived_from.uuid",
+        "annotations.source_dataset_uuid"
+      ],
+      "enable_dependency_view": true,
+      "force_rebuild_dependency_view": false,
+      "jsonify_prettyprint_regular": true,
+      "jwt_algorithm": "RS256",
+      "jwt_header_name": "Authorization",
+      "jwt_header_type": "Bearer",
+      "jwt_public_key": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n",
+      "jwt_token_location": "headers",
+      "mongo_collection": "datasets",
+      "mongo_dependency_view": "dependencies",
+      "query_dict_list_keys": [
+        "creator_usernames",
+        "base_uris",
+        "tags"
+      ],
+      "query_dict_valid_keys": [
+        "free_text",
+        "creator_usernames",
+        "base_uris",
+        "tags",
+        "query"
+      ],
+      "sqlalchemy_track_modifications": false,
+      "version": "0.14.1"
+    }
+
 See ``dtool_lookup_server.config.Config`` for more information.

--- a/dtool_lookup_server/__init__.py
+++ b/dtool_lookup_server/__init__.py
@@ -61,12 +61,14 @@ def create_app(test_config=None):
     jwt.init_app(app)
 
     from dtool_lookup_server import (
+        config_routes,
         dataset_routes,
         user_routes,
         base_uri_routes,
         user_admin_routes,
         permission_routes,
     )
+    app.register_blueprint(config_routes.bp)
     app.register_blueprint(dataset_routes.bp)
     app.register_blueprint(user_routes.bp)
     app.register_blueprint(base_uri_routes.bp)

--- a/dtool_lookup_server/config.py
+++ b/dtool_lookup_server/config.py
@@ -1,6 +1,6 @@
 import os
 
-from dtool_lookup_server import __version__
+import dtool_lookup_server
 
 _HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -44,8 +44,13 @@ class Config(object):
     @classmethod
     def to_dict(cls):
         """Convert server configuration into dict."""
-        exclusions = ['SECRET_KEY', 'JWT_PRIVATE_KEY']  # config keys to exclude
-        d = {'version': __version__}
+        exclusions = [
+            'JWT_PRIVATE_KEY',
+            'MONGO_URI',
+            'SECRET_KEY',
+            'SQLALCHEMY_DATABASE_URI',
+        ]  # config keys to exclude
+        d = {'version': dtool_lookup_server.__version__}
         for k, v in cls.__dict__.items():
             # select only capitalized fields
             if k.upper() == k and k not in exclusions:

--- a/dtool_lookup_server/config.py
+++ b/dtool_lookup_server/config.py
@@ -1,6 +1,6 @@
 import os
 
-from . import __version__
+from dtool_lookup_server import __version__
 
 _HERE = os.path.abspath(os.path.dirname(__file__))
 

--- a/dtool_lookup_server/config.py
+++ b/dtool_lookup_server/config.py
@@ -1,5 +1,7 @@
 import os
 
+from . import __version__
+
 _HERE = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -38,3 +40,14 @@ class Config(object):
         JWT_PUBLIC_KEY = _get_file_content("JWT_PUBLIC_KEY_FILE")
 
     JSONIFY_PRETTYPRINT_REGULAR = True
+
+    @classmethod
+    def to_dict(cls):
+        """Convert server configuration into dict."""
+        exclusions = ['SECRET_KEY', 'JWT_PRIVATE_KEY']  # config keys to exclude
+        d = {'version': __version__}
+        for k, v in cls.__dict__.items():
+            # select only capitalized fields
+            if k.upper() == k and k not in exclusions:
+                d[k.lower()] = v
+        return d

--- a/dtool_lookup_server/config_routes.py
+++ b/dtool_lookup_server/config_routes.py
@@ -1,0 +1,28 @@
+from flask import (
+    abort,
+    Blueprint,
+    jsonify,
+    request
+)
+from flask_jwt_extended import (
+    jwt_required,
+    get_jwt_identity,
+)
+from dtool_lookup_server import AuthenticationError
+
+from dtool_lookup_server.utils import config_to_dict
+
+
+bp = Blueprint("config", __name__, url_prefix="/admin/config")
+
+
+@bp.route("/info", methods=["GET"])
+@jwt_required
+def server_config():
+    """Return the JSON-serialized server configuration."""
+    username = get_jwt_identity()
+    try:
+        config = config_to_dict(username)
+    except AuthenticationError:
+        abort(401)
+    return jsonify(config)

--- a/dtool_lookup_server/config_routes.py
+++ b/dtool_lookup_server/config_routes.py
@@ -13,14 +13,14 @@ from dtool_lookup_server import AuthenticationError
 from dtool_lookup_server.utils import config_to_dict
 
 
-bp = Blueprint("config", __name__, url_prefix="/admin/config")
+bp = Blueprint("config", __name__, url_prefix="/config")
 
 
 @bp.route("/info", methods=["GET"])
 @jwt_required
 def server_config():
     """Return the JSON-serialized server configuration."""
-    username = get_jwt_identity()
+    username = get_jwt_identity()  # NOTE: dummy, no authentication implemented here so far
     try:
         config = config_to_dict(username)
     except AuthenticationError:

--- a/dtool_lookup_server/dataset_routes.py
+++ b/dtool_lookup_server/dataset_routes.py
@@ -17,7 +17,6 @@ from dtool_lookup_server import (
     ValidationError,
 )
 from dtool_lookup_server.utils import (
-    config_to_dict,
     dataset_info_is_valid,
     get_base_uri_obj,
     get_user_obj,
@@ -33,18 +32,6 @@ from dtool_lookup_server.utils import (
 
 
 bp = Blueprint("dataset", __name__, url_prefix="/dataset")
-
-
-@bp.route("/config", methods=["GET"])
-@jwt_required
-def server_config():
-    """Return the JSON-serialized server configuration."""
-    username = get_jwt_identity()
-    try:
-        config = config_to_dict(username)
-    except AuthenticationError:
-        abort(401)
-    return jsonify(config)
 
 
 @bp.route("/summary", methods=["GET"])

--- a/dtool_lookup_server/dataset_routes.py
+++ b/dtool_lookup_server/dataset_routes.py
@@ -17,6 +17,7 @@ from dtool_lookup_server import (
     ValidationError,
 )
 from dtool_lookup_server.utils import (
+    config_to_dict,
     dataset_info_is_valid,
     get_base_uri_obj,
     get_user_obj,
@@ -32,6 +33,18 @@ from dtool_lookup_server.utils import (
 
 
 bp = Blueprint("dataset", __name__, url_prefix="/dataset")
+
+
+@bp.route("/config", methods=["GET"])
+@jwt_required
+def server_config():
+    """Return the JSON-serialized server configuration."""
+    username = get_jwt_identity()
+    try:
+        config = config_to_dict(username)
+    except AuthenticationError:
+        abort(401)
+    return jsonify(config)
 
 
 @bp.route("/summary", methods=["GET"])

--- a/dtool_lookup_server/utils.py
+++ b/dtool_lookup_server/utils.py
@@ -122,6 +122,11 @@ def _dict_to_mongo_query(query_dict):
 # Generally useful dtool helper functions.
 #############################################################################
 
+def config_to_dict(username):
+    # So far no check on privileges
+    return Config.to_dict()
+
+
 # TODO: this function should probably live in  dtoolcore along with a test.
 def iter_datasets_in_base_uri(base_uri):
     """Yield frozen datasets in a base URI."""

--- a/dtool_lookup_server/utils.py
+++ b/dtool_lookup_server/utils.py
@@ -24,6 +24,7 @@ from dtool_lookup_server.sql_models import (
     BaseURI,
     Dataset,
 )
+from dtool_lookup_server.config import Config
 
 DATASET_INFO_REQUIRED_KEYS = (
     "uuid",

--- a/tests/test_config_routes.py
+++ b/tests/test_config_routes.py
@@ -1,0 +1,31 @@
+"""Test the /config blueprint routes."""
+
+import json
+import dtool_lookup_server
+
+from . import tmp_app_with_users  # NOQA
+
+snowwhite_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyZTk0MzMzMi0wZWE5LTQ3MWMtYTUxZS02MjUxNGNlOTdkOGMiLCJmcmVzaCI6ZmFsc2UsImlhdCI6MTU1MzI2NTM5NywidHlwZSI6ImFjY2VzcyIsIm5iZiI6MTU1MzI2NTM5NywiaWRlbnRpdHkiOiJzbm93LXdoaXRlIn0.FAoj9M4Tpr9IXIsyuD9eKV3oOpQ4_oRE82v6jqMFOSERaMqfWQgpMlTPSBsoWvnsNhigBYA7NKqqRPZ_bCHh73dMk57s6-VBvxtunQIe-MYtnOP9H4lpIdnceIE-Ji34xCd7kxIp0kADtYLhnJjU6Jesk642P0Ndjc8ePxGAl-l--bLbH_A4a3-U2EuowBSwqAp2q56QuGw6oQpKSKt9_eRSThNBE6zJIClfUeQYeCDCcd1Inh5hgrDBurteicCP8gWyVkyZ0YnjojDMECu7P9vDyy-T4AUem9EIAe_hA1nTMKucW2Ki6xyZLvu0TVlHe9AQVYy0O-suxxlrXIJ5Yw"  # NOQA
+
+def test_config_info_route(tmp_app_with_users):  # NOQA
+
+    headers = dict(Authorization="Bearer " + snowwhite_token)
+    r = tmp_app_with_users.get(
+        "/config/info",
+        headers=headers,
+    )
+    assert r.status_code == 200
+
+    # NOTE: If the configuration grows in the future, this text must adapt or will fail otherwise.
+    expected_content = {
+        'jsonify_prettyprint_regular': True,
+        'jwt_algorithm': 'RS256',
+        'jwt_header_name': 'Authorization',
+        'jwt_header_type': 'Bearer',
+        'jwt_public_key': '',
+        'jwt_token_location': 'headers',
+        'sqlalchemy_track_modifications': False,
+        'version': dtool_lookup_server.__version__}
+
+    response = json.loads(r.data.decode("utf-8"))
+    assert response == expected_content


### PR DESCRIPTION
As discussed previously, an independent config routes pull request, moved to top-level `/config` prefix, test added.

Something to think about: How to incorporate a list of installed plugins and their specific configuration key-value pairs within this route's response?