### PR TITLE
ENH: Embed plugin configurations in core config query route

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -624,10 +624,17 @@ will return the current server configuration with all keys in lowercase, i.e.::
       "jwt_public_key": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n",
       "jwt_token_location": "headers",
       "sqlalchemy_track_modifications": false,
-      "version": "0.14.1"
+      "version": "0.14.1",
+      "dtool_lookup_server_plugin_scaffolding": {
+        "some_public_plugin_specific_setting": "public",
+        "version": "0.1.2"
+      }
     }
 
-See ``dtool_lookup_server.config.Config`` for more information.
+If any dtool server plugins are installed,  their configuration is embedded 
+in thesponse as shown for the dummy ``dtool_lookup_server_plugin_scaffolding``
+plugin above. See ``dtool_lookup_server.config.Config`` and 
+``dtool_lookup_server.utils.config_to_dict``for more information.
 
 
 Creating a plugin

--- a/tests/test_config_routes.py
+++ b/tests/test_config_routes.py
@@ -28,4 +28,8 @@ def test_config_info_route(tmp_app_with_users):  # NOQA
         'version': dtool_lookup_server.__version__}
 
     response = json.loads(r.data.decode("utf-8"))
-    assert response == expected_content
+
+    # this allows the test to succeed if more config options enter in the future
+    for k, v in expected_content.items():
+        assert k in response
+        assert v == response[k]


### PR DESCRIPTION
This implements the discussed extension to the config query route. Plugin configurations are nested below a a key with the plugin's name (see added sample in README). Let me know if you would want to have it slightly different.