### PR TITLE
sqlalchemy pagination api changed from 2.x to 3.x

### DIFF
--- a/dtool_lookup_server/base_uri_routes.py
+++ b/dtool_lookup_server/base_uri_routes.py
@@ -58,5 +58,7 @@ def base_uri_list(pagination_parameters):
     query = BaseURI.query.filter_by()
     pagination_parameters.item_count = query.count()
     return query.paginate(
-        pagination_parameters.page, pagination_parameters.page_size, True
+        page=pagination_parameters.page,
+        per_page=pagination_parameters.page_size,
+        error_out=True
     ).items

--- a/dtool_lookup_server/user_admin_routes.py
+++ b/dtool_lookup_server/user_admin_routes.py
@@ -9,9 +9,6 @@ from flask_jwt_extended import (
 from flask_smorest import Blueprint
 from flask_smorest.pagination import PaginationParameters
 
-from dtool_lookup_server import (
-    AuthenticationError,
-)
 from dtool_lookup_server.schemas import RegisterUserSchema
 from dtool_lookup_server.sql_models import (
     User,
@@ -62,5 +59,7 @@ def list_users(pagination_parameters: PaginationParameters):
     query = User.query.filter_by()
     pagination_parameters.item_count = query.count()
     return query.paginate(
-        pagination_parameters.page, pagination_parameters.page_size, True
+        page=pagination_parameters.page,
+        per_page=pagination_parameters.page_size,
+        error_out=True
     ).items


### PR DESCRIPTION
sqlalchemy pagination api changed from 2.x to 3.x, make compliant with https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/api/#flask_sqlalchemy.SQLAlchemy.paginate
and resolve  the following error,

```
tmp_app_with_data = <FlaskClient <Flask 'dtool_lookup_server'>>

    def test_base_uri_list_route(tmp_app_with_data):  # NOQA
    
        headers = dict(Authorization="Bearer " + snowwhite_token)
        r = tmp_app_with_data.get(
            "/admin/base_uri/list",
            headers=headers,
        )
>       assert r.status_code == 200
E       assert 500 == 200
E        +  where 500 = <WrapperTestResponse streamed [500 INTERNAL SERVER ERROR]>.status_code

tests/test_base_uri_routes.py:71: AssertionError
------------------------------------------------------------------------------------------------ Captured log call ------------------------------------------------------------------------------------------------
ERROR    dtool_lookup_server:app.py:1741 Exception on /admin/base_uri/list [GET]
Traceback (most recent call last):
  File "/mnt/dat2/git/dtool/dtool-lookup-server/venv/lib/python3.8/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/mnt/dat2/git/dtool/dtool-lookup-server/venv/lib/python3.8/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/mnt/dat2/git/dtool/dtool-lookup-server/venv/lib/python3.8/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/mnt/dat2/git/dtool/dtool-lookup-server/venv/lib/python3.8/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/mnt/dat2/git/dtool/dtool-lookup-server/venv/lib/python3.8/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/mnt/dat2/git/dtool/dtool-lookup-server/venv/lib/python3.8/site-packages/flask_smorest/pagination.py", line 199, in wrapper
    result, status, headers = unpack_tuple_response(func(*args, **kwargs))
  File "/mnt/dat2/git/dtool/dtool-lookup-server/venv/lib/python3.8/site-packages/flask_smorest/response.py", line 90, in wrapper
    func(*args, **kwargs)
  File "/mnt/dat2/git/dtool/dtool-lookup-server/venv/lib/python3.8/site-packages/flask_jwt_extended/view_decorators.py", line 154, in decorator
    return current_app.ensure_sync(fn)(*args, **kwargs)
  File "/mnt/dat2/git/dtool/dtool-lookup-server/dtool_lookup_server/base_uri_routes.py", line 60, in base_uri_list
    return query.paginate(
TypeError: paginate() takes 1 positional argument but 4 were given
```
