### PR TITLE
Uri to URI

### DIFF
--- a/dtool_lookup_server/base_uri_routes.py
+++ b/dtool_lookup_server/base_uri_routes.py
@@ -7,9 +7,6 @@ from flask_jwt_extended import (
 )
 from flask_smorest import Blueprint
 
-from dtool_lookup_server import (
-    AuthenticationError,
-)
 from dtool_lookup_server.sql_models import BaseURISchema, BaseURI
 import dtool_lookup_server.utils_auth
 from dtool_lookup_server.utils import (

--- a/dtool_lookup_server/dataset_routes.py
+++ b/dtool_lookup_server/dataset_routes.py
@@ -28,7 +28,7 @@ from dtool_lookup_server import (
     ValidationError,
 )
 from dtool_lookup_server.schemas import (
-    UriSchema,
+    URISchema,
     RegisterDatasetSchema,
     SearchDatasetSchema,
     SummarySchema,
@@ -195,8 +195,7 @@ def readme(query: UriSchema):
 
 
 @bp.route("/annotations", methods=["POST"])
-@bp.arguments(UriSchema)
-@bp.response(200, Dict)
+@bp.arguments(URISchema)
 @jwt_required()
 def annotations(query: UriSchema):
     """Request the dataset annotations."""

--- a/dtool_lookup_server/dataset_routes.py
+++ b/dtool_lookup_server/dataset_routes.py
@@ -118,7 +118,7 @@ def search_datasets(
 
 @bp.route("/register", methods=["POST"])
 @bp.arguments(RegisterDatasetSchema(partial=("created_at",)))
-@bp.response(201, UriSchema)
+@bp.response(201, URISchema)
 @jwt_required()
 def register(dataset: RegisterDatasetSchema):
     """Register a dataset. The user needs to have register permissions on the base_uri."""
@@ -143,9 +143,9 @@ def register(dataset: RegisterDatasetSchema):
 # - may_search
 
 @bp.route("/manifest", methods=["POST"])
-@bp.arguments(UriSchema)
+@bp.arguments(URISchema)
 @jwt_required()
-def manifest(query: UriSchema):
+def manifest(query: URISchema):
     """Request the dataset manifest."""
     username = get_jwt_identity()
     if not dtool_lookup_server.utils_auth.user_exists(username):
@@ -169,9 +169,9 @@ def manifest(query: UriSchema):
 
 
 @bp.route("/readme", methods=["POST"])
-@bp.arguments(UriSchema)
+@bp.arguments(URISchema)
 @jwt_required()
-def readme(query: UriSchema):
+def readme(query: URISchema):
     """Request the dataset readme."""
     username = get_jwt_identity()
     if not dtool_lookup_server.utils_auth.user_exists(username):
@@ -197,7 +197,7 @@ def readme(query: UriSchema):
 @bp.route("/annotations", methods=["POST"])
 @bp.arguments(URISchema)
 @jwt_required()
-def annotations(query: UriSchema):
+def annotations(query: URISchema):
     """Request the dataset annotations."""
     username = get_jwt_identity()
     if not dtool_lookup_server.utils_auth.user_exists(username):

--- a/dtool_lookup_server/dataset_routes.py
+++ b/dtool_lookup_server/dataset_routes.py
@@ -12,7 +12,6 @@ from flask_smorest import Blueprint
 from flask_smorest.pagination import PaginationParameters
 
 from .sql_models import (
-    BaseURISchema,
     DatasetSchema
 )
 

--- a/dtool_lookup_server/permission_routes.py
+++ b/dtool_lookup_server/permission_routes.py
@@ -11,7 +11,8 @@ from dtool_lookup_server import (
     AuthenticationError,
     ValidationError
 )
-from dtool_lookup_server.schemas import BaseUriSchema, UriPermissionSchema
+from dtool_lookup_server.schemas import UriPermissionSchema
+from dtool_lookup_server.sql_models import BaseURISchema
 
 bp = Blueprint("permissions", __name__, url_prefix="/admin/permission")
 

--- a/dtool_lookup_server/permission_routes.py
+++ b/dtool_lookup_server/permission_routes.py
@@ -21,7 +21,7 @@ bp = Blueprint("permissions", __name__, url_prefix="/admin/permission")
 @bp.arguments(BaseURISchema)
 @bp.response(200, URIPermissionSchema)
 @jwt_required()
-def permission_info(data: BaseUriSchema):
+def permission_info(data: BaseURISchema):
     """Get information about the permissions on a base URI.
 
     The user needs to be admin.

--- a/dtool_lookup_server/permission_routes.py
+++ b/dtool_lookup_server/permission_routes.py
@@ -11,15 +11,15 @@ from dtool_lookup_server import (
     AuthenticationError,
     ValidationError
 )
-from dtool_lookup_server.schemas import UriPermissionSchema
+from dtool_lookup_server.schemas import URIPermissionSchema
 from dtool_lookup_server.sql_models import BaseURISchema
 
 bp = Blueprint("permissions", __name__, url_prefix="/admin/permission")
 
 
 @bp.route("/info", methods=["POST"])
-@bp.arguments(BaseUriSchema)
-@bp.response(200, UriPermissionSchema)
+@bp.arguments(BaseURISchema)
+@bp.response(200, URIPermissionSchema)
 @jwt_required()
 def permission_info(data: BaseUriSchema):
     """Get information about the permissions on a base URI.
@@ -40,9 +40,9 @@ def permission_info(data: BaseUriSchema):
 
 
 @bp.route("/update_on_base_uri", methods=["POST"])
-@bp.arguments(UriPermissionSchema)
+@bp.arguments(URIPermissionSchema)
 @jwt_required()
-def update_on_base_uri(permissions: UriPermissionSchema):
+def update_on_base_uri(permissions: URIPermissionSchema):
     """Update the permissions on a base URI.
 
     The user needs to be admin.

--- a/dtool_lookup_server/schemas.py
+++ b/dtool_lookup_server/schemas.py
@@ -79,7 +79,3 @@ class UserResponseSchema(Schema):
     is_admin = Boolean()
     register_permissions_on_base_uris = List(String)
     search_permissions_on_base_uris = List(String)
-
-
-class AnnotationsSchema(Schema):
-    pass

--- a/dtool_lookup_server/schemas.py
+++ b/dtool_lookup_server/schemas.py
@@ -79,3 +79,7 @@ class UserResponseSchema(Schema):
     is_admin = Boolean()
     register_permissions_on_base_uris = List(String)
     search_permissions_on_base_uris = List(String)
+
+
+class AnnotationsSchema(Schema):
+    pass

--- a/dtool_lookup_server/schemas.py
+++ b/dtool_lookup_server/schemas.py
@@ -51,7 +51,7 @@ class RegisterDatasetSchema(Schema):
     size_in_bytes = Integer()
 
 
-class UriPermissionSchema(Schema):
+class URIPermissionSchema(Schema):
     base_uri = String()
     users_with_register_permissions = List(String)
     users_with_search_permissions = List(String)

--- a/dtool_lookup_server/schemas.py
+++ b/dtool_lookup_server/schemas.py
@@ -15,10 +15,6 @@ class UriSchema(Schema):
     uri = String()
 
 
-class BaseUriSchema(Schema):
-    base_uri = String()
-
-
 class RegisterUserSchema(Schema):
     username = String()
     is_admin = Boolean()

--- a/dtool_lookup_server/schemas.py
+++ b/dtool_lookup_server/schemas.py
@@ -11,7 +11,7 @@ from marshmallow.fields import (
 )
 
 
-class UriSchema(Schema):
+class URISchema(Schema):
     uri = String()
 
 


### PR DESCRIPTION
We use the acronym URI all capitalized in Error names and documentation, let's make it consistent.

* Standardized spelling of Uri to URI in models and schemas for all occurrences. 
* There have been two overlapping definitions of `BaseUriSchema` in `sql_models.py` and `schemas.py`. Do we need two distinct definitons? Threw out one of them.
* There have been issues with inconsistent capitalization and overlap of class names when auto-generating client API from the REST documentation (more detail https://github.com/jic-dtool/dtool-lookup-server/pull/27).