### PR TITLE
openapi specs configurable

### DIFF
--- a/dtool_lookup_server/config.py
+++ b/dtool_lookup_server/config.py
@@ -64,11 +64,11 @@ class Config(object):
                 "bearerAuth": {
                     "type": "http",
                     "scheme": "bearer",
-                    "bearerFormat": "JWT",
+                    "bearerFormat": "JWT"
                 }
             }
-        },
-    }
+        }
+    }"""))
 
     @classmethod
     def to_dict(cls):

--- a/dtool_lookup_server/config.py
+++ b/dtool_lookup_server/config.py
@@ -49,13 +49,13 @@ class Config(object):
     API_TITLE = "dtool-lookup-server API"
     API_VERSION = "v1"
     OPENAPI_VERSION = "3.0.2"
-    OPENAPI_URL_PREFIX = "/doc"
-    OPENAPI_REDOC_PATH = "/redoc"
-    OPENAPI_REDOC_URL = (
+    OPENAPI_URL_PREFIX = os.environ.get("OPENAPI_URL_PREFIX", "/doc")
+    OPENAPI_REDOC_PATH = os.environ.get("OPENAPI_REDOC_PATH", "/redoc")
+    OPENAPI_REDOC_URL = os.environ.get("OPENAPI_REDOC_URL",
         "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"
     )
-    OPENAPI_SWAGGER_UI_PATH = "/swagger"
-    OPENAPI_SWAGGER_UI_URL = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
+    OPENAPI_SWAGGER_UI_PATH = os.environ.get("OPENAPI_SWAGGER_UI_PATH", "/swagger")
+    OPENAPI_SWAGGER_UI_URL = os.environ.get("OPENAPI_SWAGGER_UI_URL", "https://cdn.jsdelivr.net/npm/swagger-ui-dist/")
     API_SPEC_OPTIONS = {
         "x-internal-id": "2",
         "security": [{"bearerAuth": []}],

--- a/dtool_lookup_server/config.py
+++ b/dtool_lookup_server/config.py
@@ -68,7 +68,7 @@ class Config(object):
                     "bearerFormat": "JWT"
                 }
             }
-        },
+        }
     }"""))
 
     @classmethod

--- a/dtool_lookup_server/config.py
+++ b/dtool_lookup_server/config.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import dtool_lookup_server
@@ -56,7 +57,7 @@ class Config(object):
     )
     OPENAPI_SWAGGER_UI_PATH = os.environ.get("OPENAPI_SWAGGER_UI_PATH", "/swagger")
     OPENAPI_SWAGGER_UI_URL = os.environ.get("OPENAPI_SWAGGER_UI_URL", "https://cdn.jsdelivr.net/npm/swagger-ui-dist/")
-    API_SPEC_OPTIONS = {
+    API_SPEC_OPTIONS = json.loads(os.environ.get("API_SPEC_OPTIONS", """{
         "x-internal-id": "2",
         "security": [{"bearerAuth": []}],
         "components": {
@@ -67,7 +68,7 @@ class Config(object):
                     "bearerFormat": "JWT"
                 }
             }
-        }
+        },
     }"""))
 
     @classmethod

--- a/dtool_lookup_server/config.py
+++ b/dtool_lookup_server/config.py
@@ -57,19 +57,26 @@ class Config(object):
     )
     OPENAPI_SWAGGER_UI_PATH = os.environ.get("OPENAPI_SWAGGER_UI_PATH", "/swagger")
     OPENAPI_SWAGGER_UI_URL = os.environ.get("OPENAPI_SWAGGER_UI_URL", "https://cdn.jsdelivr.net/npm/swagger-ui-dist/")
-    API_SPEC_OPTIONS = json.loads(os.environ.get("API_SPEC_OPTIONS", """{
-        "x-internal-id": "2",
-        "security": [{"bearerAuth": []}],
-        "components": {
-            "securitySchemes": {
-                "bearerAuth": {
-                    "type": "http",
-                    "scheme": "bearer",
-                    "bearerFormat": "JWT"
+
+    # give API_SPEC_OPTIONS priority over API_SPEC_OPTIONS_FILE over default value
+    if os.environ.get("API_SPEC_OPTIONS"):
+        API_SPEC_OPTIONS = json.loads(os.environ.get("API_SPEC_OPTIONS"))
+    elif os.environ.get("API_SPEC_OPTIONS_FILE"):
+        API_SPEC_OPTIONS = json.loads(_get_file_content("API_SPEC_OPTIONS_FILE"))
+    else:
+        API_SPEC_OPTIONS = {
+            "x-internal-id": "2",
+            "security": [{"bearerAuth": []}],
+            "components": {
+                "securitySchemes": {
+                    "bearerAuth": {
+                        "type": "http",
+                        "scheme": "bearer",
+                        "bearerFormat": "JWT"
+                    }
                 }
             }
         }
-    }"""))
 
     @classmethod
     def to_dict(cls):


### PR DESCRIPTION
This or some similar mechanism is necessary for having the app run with a custom prefix, as is i.e. the case for https://demo.dtool.dev/lookup/doc/swagger 