### PR TITLE
For discussion: explicitly hold timestamps at as Float() in db?

### DIFF
--- a/dtool_lookup_server/sql_models.py
+++ b/dtool_lookup_server/sql_models.py
@@ -2,6 +2,8 @@ import dtoolcore.utils
 from dtool_lookup_server import ma
 from dtool_lookup_server import sql_db as db
 
+from marshmallow.fields import Float
+
 search_permissions = db.Table(
     "search_permissions",
     db.Column("user_id", db.Integer, db.ForeignKey("user.id"), primary_key=True),
@@ -120,7 +122,12 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = User
 
+
 class DatasetSchema(ma.SQLAlchemyAutoSchema):
+    created_at = Float()
+    frozen_at = Float()
+
     class Meta:
         model = Dataset
-        fields = ('base_uri', 'created_at', 'creator_username', 'frozen_at', 'created_at', 'name', 'uri', 'uuid')
+        additional = ('base_uri', 'creator_username', 'name', 'uri', 'uuid')
+


### PR DESCRIPTION
Originally, `sql_models.Dataset(db.Model)` defines columns `frozen_at` and `created_at` as `db.DateTime()`, its method `as_dict()` converts those with `dtoolcore.utils.timestamp(self.frozen_at)`. This, however, results in the autogenerated client API to expect a serialized datetime object and to throw an exception when receiving float. Treat created_at and frozen_at as floats in schema with
https://github.com/jotelha/dtool-lookup-server/blob/9d1b8cc751f1d1e143bae10d9454d86be438dc13/dtool_lookup_server/sql_models.py#L122-L128 as suggested below https://marshmallow.readthedocs.io/en/latest/quickstart.html#implicit-field-creation. 

Not sure whether this issue would still persist, a lot has changed on the code since first encountered in https://github.com/jic-dtool/dtool-lookup-server/pull/24.

