### PR TITLE
ENH: expose X-Pagination response header

### DIFF
--- a/dtool_lookup_server/__init__.py
+++ b/dtool_lookup_server/__init__.py
@@ -170,14 +170,14 @@ for entrypoint in iter_entry_points("dtool_lookup_server.extension"):
 def create_app(test_config=None):
     app = Flask(__name__)
 
-    CORS(app)
-
     if test_config is None:
         # load the instance config, if it exists, when not testing
         app.config.from_object(Config)
     else:
         # load the test config if passed in
         app.config.from_mapping(test_config)
+
+    CORS(app)
 
     retrieve.init_app(app)
     search.init_app(app)

--- a/dtool_lookup_server/config.py
+++ b/dtool_lookup_server/config.py
@@ -49,6 +49,23 @@ class Config(object):
 
     API_TITLE = "dtool-lookup-server API"
     API_VERSION = "v1"
+
+    # flask_smorest.Blueprint.paginate embeds pagination information like
+    # {
+    #     'total': 1000, 'total_pages': 200,
+    #     'page': 2, 'first_page': 1, 'last_page': 200,
+    #     'previous_page': 1, 'next_page': 3,
+    # }
+    # in the response header 'X-Pagination', see
+    #    https://flask-smorest.readthedocs.io/en/latest/pagination.html#pagination-header
+    # To make client request frameworks like axios expose these data to the
+    # actual app, e.g. the dtool-lookup-webapp, the server needs to indicate
+    # the wish to do so, see
+    #     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+    # With flask, this is achieved by configuring flask-cors as follows, see
+    #     https://flask-cors.readthedocs.io/en/latest/configuration.html#configuration-options
+    CORS_EXPOSE_HEADERS = ["X-Pagination"]
+
     OPENAPI_VERSION = "3.0.2"
     OPENAPI_URL_PREFIX = os.environ.get("OPENAPI_URL_PREFIX", "/doc")
     OPENAPI_REDOC_PATH = os.environ.get("OPENAPI_REDOC_PATH", "/redoc")


### PR DESCRIPTION
This is necessary on server-side to expose the x-pagination header to client apps, and we need this for implementing https://github.com/livMatS/dtool-lookup-webapp/tree/pagination. 

`flask_smorest.Blueprint.paginate` embeds pagination information like
```json
{
    'total': 1000, 'total_pages': 200,
    'page': 2, 'first_page': 1, 'last_page': 200,
    'previous_page': 1, 'next_page': 3,
}
```
in the response header `'X-Pagination'`, see https://flask-smorest.readthedocs.io/en/latest/pagination.html#pagination-header. 

To make client request frameworks like `axios` expose these data to the actual app, e.g. the `dtool-lookup-webapp`, the server needs to indicate the wish to do so, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers. 

With flask, this is achieved by configuring `flask-cors` accordingly, see https://flask-cors.readthedocs.io/en/latest/configuration.html#configuration-options.