### PR TITLE
Github- and docker-sepcific extensions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Install search and retrieve plugins
       run: | 
         # This should move into the strategy matrix once released 
-        pip install git+https://github.com/jotelha/dtool-lookup-server-search-plugin-mongo.git@main
-        pip install git+https://github.com/jotelha/dtool-lookup-server-retrieve-plugin-mongo.git@main
+        pip install git+https://github.com/jic-dtool/dtool-lookup-server-search-plugin-mongo.git@main
+        pip install git+https://github.com/jic-dtool/dtool-lookup-server-retrieve-plugin-mongo.git@main
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Install search and retrieve plugins
       run: | 
         # This should move into the strategy matrix once released 
-        pip install git+https://github.com/jic-dtool/dtool-lookup-server-search-plugin-mongo.git@main
-        pip install git+https://github.com/jic-dtool/dtool-lookup-server-retrieve-plugin-mongo.git@main
+        pip install git+https://github.com/jotelha/dtool-lookup-server-search-plugin-mongo.git@main
+        pip install git+https://github.com/jotelha/dtool-lookup-server-retrieve-plugin-mongo.git@main
 
     - name: Test with pytest
       run: |

--- a/README.rst
+++ b/README.rst
@@ -5,13 +5,9 @@ Dtool Lookup Server
    :target: http://badge.fury.io/py/dtool-lookup-server
    :alt: PyPi package
 
-.. image:: https://travis-ci.org/jic-dtool/dtool-lookup-server.svg?branch=master
-   :target: https://travis-ci.org/jic-dtool/dtool-lookup-server
-   :alt: Travis CI build status (Linux)
-
-.. image:: https://codecov.io/github/jic-dtool/dtool-lookup-server/coverage.svg?branch=master
-   :target: https://codecov.io/github/jic-dtool/dtool-lookup-server?branch=master
-   :alt: Code Coverage
+.. image:: https://img.shields.io/github/actions/workflow/status/jotelha/dtool-lookup-server/test.yml?branch=main
+    :target: https://github.com/livMatS/dtool-lookup-gui/actions/workflows/test.yml
+    :alt: GitHub Workflow Status
 
 - GitHub: https://github.com/jic-dtool/dtool-lookup-server
 - PyPI: https://pypi.python.org/pypi/dtool-lookup-server

--- a/devel/README.md
+++ b/devel/README.md
@@ -5,6 +5,9 @@ Helper components of a simple development setup.
 Provide necessary services with docker composition `docker/env.yml`. 
 See `docker/README.md`.
 
+`dtool.json` provides a minimal configuration for a lookup server launched as
+described in the following. Place it at `${HOME}/.config/dtool/dtool.json`.
+
 `env.rc` provides flask app configuration in form of environment varables.
 
 `create_test_data.sh` creates test data sets and copis them to test s3 bucket.
@@ -12,6 +15,32 @@ See `docker/README.md`.
 `init.sh` prepares the lookup server.
 
 `run.sh` launches the lookup server with `gunicorn`.
+
+# Example envrionment
+
+Create a virtual environment with
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+
+pip install gunicorn psycopg2 setuptools_scm wheel
+pip install -r requirements.txt
+pip install dtool-cli dtool-info dtool-create dtool-s3
+pip install git+https://github.com/jotelha/dtool-lookup-server-retrieve-plugin-mongo.git@main
+pip install git+https://github.com/jotelha/dtool-lookup-server-search-plugin-mongo.git@main
+pip install git+https://github.com/livMatS/dtool-lookup-server-direct-mongo-plugin.git@main
+pip install git+https://github.com/livMatS/dtool-lookup-server-dependency-graph-plugin.git@main
+pip install git+https://github.com/livMatS/dtool-lookup-server-notification-plugin.git@main
+```
+
+and launch server with
+
+```bash
+source devel/env.rc
+bash devel/init.sh
+bash devel/run.sh
+```
 
 ## On Ubunu (20.04)
 

--- a/devel/dtool.json
+++ b/devel/dtool.json
@@ -1,0 +1,10 @@
+{
+  "DTOOL_S3_ENDPOINT_test-bucket": "http://localhost:9000",
+  "DTOOL_S3_ACCESS_KEY_ID_test-bucket": "admin",
+  "DTOOL_S3_SECRET_ACCESS_KEY_test-bucket": "secret12",
+  "DTOOL_LOOKUP_SERVER_TOKEN_GENERATOR_URL": "http://localhost:5001/token",
+  "DTOOL_LOOKUP_SERVER_URL": "http://localhost:5000",
+  "DTOOL_LOOKUP_SERVER_USERNAME": "test-user",
+  "DTOOL_LOOKUP_SERVER_PASSWORD": "test-password",
+  "DTOOL_LOOKUP_SERVER_VERIFY_SSL": "false"
+}

--- a/devel/env.rc
+++ b/devel/env.rc
@@ -1,0 +1,18 @@
+export FLASK_APP=dtool_lookup_server
+export SQLALCHEMY_DATABASE_URI=postgresql://admin:secret12@localhost:5432/dtool
+export SEARCH_MONGO_URI=mongodb://localhost:27017/
+export SEARCH_MONGO_DB=dtool_info
+export SEARCH_MONGO_COLLECTION=datasets
+export RETRIEVE_MONGO_URI=mongodb://localhost:27017/
+export RETRIEVE_MONGO_DB=dtool_info
+export RETRIEVE_MONGO_COLLECTION=datasets
+export JWT_PUBLIC_KEY_FILE=$(pwd)/docker/keys/jwt_key.pub
+export JWT_PRIVATE_KEY_FILE=$(pwd)/docker/keys/jwt_key
+export DUMP_HTTP_REQUESTS=True
+export LOGLEVEL=DEBUG
+
+# direct-mongo-plugin settings
+export MONGO_URI=mongodb://localhost:27017/
+export MONGO_DB=dtool_info
+export MONGO_COLLECTION=metadata
+export ALLOW_DIRECT_AGGREGATION=true

--- a/docker/README.md
+++ b/docker/README.md
@@ -41,11 +41,23 @@ Similar to the development setup, but only provides all services the lookup
 server depends on, not the lookup server itsels. Useful for playing with
 different plugin constellations.
 
+To share keys between containerized token generator and the host environment,
+keys are generated on a bind mount when launchingthe composition.
+
+Prepare an empty folder `keys` within this direcotry (meaning at `docker/keys`
+relative to the repository root) before launching any container composition.
+
+Otherwise, `docker compose` will not launch.
+
 Build the compose environment with
 ```
 docker compose -f docker/env.yml build
 ```
 and start it with
 ```
-docker compose -f docker/env.yml up
+docker compose -f docker/env.yml up -d
 ```
+
+Make keys generated at container launch readible by current user on host with
+
+    sudo chown -R ${USER}:${USER} docker/keys

--- a/docker/dtool_lookup_server_devel/Dockerfile
+++ b/docker/dtool_lookup_server_devel/Dockerfile
@@ -12,8 +12,8 @@ RUN pip install -U pip  && \
     pip install gunicorn  psycopg2 setuptools_scm && \
     pip install -r requirements.txt && \
     pip install dtool-cli dtool-info dtool-create dtool-s3 && \
-    pip install git+https://github.com/jotelha/dtool-lookup-server-retrieve-plugin-mongo.git@main && \
-    pip install git+https://github.com/jotelha/dtool-lookup-server-search-plugin-mongo.git@main && \
+    pip install git+https://github.com/jic-dtool/dtool-lookup-server-retrieve-plugin-mongo.git@main && \
+    pip install git+https://github.com/jic-dtool/dtool-lookup-server-search-plugin-mongo.git@main && \
     pip install git+https://github.com/livMatS/dtool-lookup-server-direct-mongo-plugin.git@main && \
     pip install git+https://github.com/livMatS/dtool-lookup-server-dependency-graph-plugin.git@main && \
     pip install git+https://github.com/livMatS/dtool-lookup-server-notification-plugin.git@main && \

--- a/docker/dtool_lookup_server_devel/Dockerfile
+++ b/docker/dtool_lookup_server_devel/Dockerfile
@@ -9,11 +9,14 @@ WORKDIR /app
 ENV FLASK_APP=dtool_lookup_server
 
 RUN pip install -U pip  && \
-    pip install gunicorn  psycopg2 && \
+    pip install gunicorn  psycopg2 setuptools_scm && \
     pip install -r requirements.txt && \
     pip install dtool-cli dtool-info dtool-create dtool-s3 && \
-    pip install git+https://github.com/jotelha/dtool-lookup-server-retrieve-plugin-mongo.git@2022-11-23-config && \
-    pip install git+https://github.com/jotelha/dtool-lookup-server-search-plugin-mongo.git@2022-11-22-config && \
+    pip install git+https://github.com/jotelha/dtool-lookup-server-retrieve-plugin-mongo.git@main && \
+    pip install git+https://github.com/jotelha/dtool-lookup-server-search-plugin-mongo.git@main && \
+    pip install git+https://github.com/livMatS/dtool-lookup-server-direct-mongo-plugin.git@main && \
+    pip install git+https://github.com/livMatS/dtool-lookup-server-dependency-graph-plugin.git@main && \
+    pip install git+https://github.com/livMatS/dtool-lookup-server-notification-plugin.git@main && \
     rm -rf /root/.cache/pip
 
 COPY docker/dtool_lookup_server_devel/dtool.json /home/dtool_lookup_server/.config/dtool/

--- a/docker/env.yml
+++ b/docker/env.yml
@@ -4,45 +4,8 @@ volumes:
   postgres_data: {}
   mongo_data: {}
   minio_data: {}
-  key_data: {}
 
 services:
-  dtool_lookup_server:
-    build:
-      context: ..
-      dockerfile: ./docker/dtool_lookup_server_devel/Dockerfile
-    image: local_dtool_lookup_server
-    depends_on:
-      postgres:
-        condition: service_started
-      mongo:
-        condition: service_started
-      minio:
-        condition: service_started
-      minio-create-buckets:
-        condition: service_completed_successfully
-    volumes:
-      - ..:/app
-      - key_data:/keys
-    environment:
-      - SQLALCHEMY_DATABASE_URI=postgresql://admin:secret12@postgres:5432/dtool
-      # - MONGO_URI=mongodb://mongo:27017/dtool_info
-      - SEARCH_MONGO_URI=mongodb://mongo:27017/
-      - SEARCH_MONGO_DB=dtool_info
-      - SEARCH_MONGO_COLLECTION=datasets
-      - RETRIEVE_MONGO_URI=mongodb://mongo:27017/
-      - RETRIEVE_MONGO_DB=dtool_info
-      - RETRIEVE_MONGO_COLLECTION=datasets
-      - MONGO_URI=mongodb://mongo:27017/
-      - MONGO_DB=dtool_info
-      - MONGO_COLLECTION=metadata
-      - JWT_PUBLIC_KEY_FILE=/keys/jwt_key.pub
-      - JWT_PRIVATE_KEY_FILE=/keys/jwt_key
-      - DUMP_HTTP_REQUESTS=True
-      - LOGLEVEL=DEBUG
-    ports:
-      - "5000:5000"
-
   postgres:
     image: postgres:latest
     restart: always
@@ -98,18 +61,34 @@ services:
         exit 0;
         "
 
+  create-jwt-keys:
+    image: alpine/openssl
+    volumes:
+      - type: bind
+        source: ./keys
+        target: /keys
+
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/openssl genrsa -out /keys/jwt_key 2048;
+      /usr/bin/openssl rsa -in /keys/jwt_key -pubout -outform PEM -out /keys/jwt_key.pub;
+      exit 0;
+      "
+
   token_generator_ldap:
     hostname: token-generator-ldap
     image: jotelha/dtool-token-generator-ldap:latest
     restart: always
     command: /start
     volumes:
-      - key_data:/keys
+      - type: bind
+        source: ./keys
+        target: /keys
     depends_on:
       ldap:
         condition: service_started
-      dtool_lookup_server:
-        condition: service_started
+      create-jwt-keys:
+        condition: service_completed_successfully
     environment:
       - FLASK_APP=app.py
       - FLASK_CONFIG_FILE=production.cfg

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         ],
     },
     install_requires=[
-        "flask",
+        "flask<3",
         "pymongo",
         "alembic",
         "flask-sqlalchemy",


### PR DESCRIPTION
* Enable dependabot
* Refer to github workflows instead of Travis CI in README
* Add docker-compose.yml for development environment (meaning services like token generator, object storage, databases, ... but without the dtool-lookup-server itself) 
* Provide some documentation on how to install a valid dtool-lookup-server testing instance that runs against these basic services#
* Provide a sample configuration for this case