### PR TITLE
MAINT: declare requires-python and add test extras for search/retrieve plugins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
     {name = "Tjelvar Olsson", email = "tjelvar.olsson@gmail.com"}
 ]
 dynamic = ["version"]
+requires-python = ">=3.8"
 dependencies = [
         "setuptools",
         "flask<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
 test = [
     "pytest",
     "pytest-cov",
+    "dserver-search-plugin-mongo",
+    "dserver-retrieve-plugin-mongo",
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
## Summary
- Add `requires-python = ">=3.8"` to `pyproject.toml`
- Add `dserver-search-plugin-mongo` and `dserver-retrieve-plugin-mongo` as optional test dependencies so `pip install -e ".[test]"` installs everything needed to run the full test suite (previously 70 tests errored with "Please install a search plugin")